### PR TITLE
DozeSensors: only use proximity sensor if supported

### DIFF
--- a/packages/SystemUI/res/values/lineage_config.xml
+++ b/packages/SystemUI/res/values/lineage_config.xml
@@ -34,4 +34,7 @@
     <!-- QuickSettings configs -->
     <bool name="qs_tile_vertical_layout">false</bool>
     <integer name="quick_qs_panel_max_columns">4</integer>
+
+    <!-- Whether usage of the proximity sensor during doze is supported -->
+    <bool name="doze_proximity_sensor_supported">true</bool>
 </resources>

--- a/packages/SystemUI/src/com/android/systemui/doze/DozeSensors.java
+++ b/packages/SystemUI/src/com/android/systemui/doze/DozeSensors.java
@@ -48,6 +48,7 @@ import com.android.internal.logging.UiEventLogger;
 import com.android.internal.logging.UiEventLoggerImpl;
 import com.android.keyguard.KeyguardUpdateMonitor;
 import com.android.systemui.biometrics.AuthController;
+import com.android.systemui.R;
 import com.android.systemui.plugins.SensorManagerPlugin;
 import com.android.systemui.statusbar.phone.DozeParameters;
 import com.android.systemui.statusbar.policy.DevicePostureController;
@@ -259,14 +260,15 @@ public class DozeSensors {
                         false /* ignoresSetting */,
                         false /* requiresProx */),
         };
-        setProxListening(false);  // Don't immediately start listening when we register.
-        mProximitySensor.register(
-                proximityEvent -> {
-                    if (proximityEvent != null) {
-                        mProxCallback.accept(!proximityEvent.getBelow());
-                    }
-                });
-
+        if (context.getResources().getBoolean(R.bool.doze_proximity_sensor_supported)) {
+            setProxListening(false);  // Don't immediately start listening when we register.
+            mProximitySensor.register(
+                    proximityEvent -> {
+                        if (proximityEvent != null) {
+                            mProxCallback.accept(!proximityEvent.getBelow());
+                        }
+                    });
+        }
         mDevicePostureController.addCallback(mDevicePostureCallback);
     }
 


### PR DESCRIPTION
On msm-4.14 devices, when the proximity sensor is in use,
the smp2p-sleepstate IRQ is fired multiple times a second,
with each one holding a 200ms wakelock.
This is probably a bug in the DSP firmware.
To fix this, avoid using the proximity sensor in doze mode,
because sleep is preferred to turning off the screen.

Change-Id: I57750afd77267abdc49780f70636626d20e666ad